### PR TITLE
Use exec form instead of shell form for CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ ENV REGISTRY_CONFIG /var/lib/docker-registry-manager/config.yml
 VOLUME ["/var/lib/docker-registry-manager"]
 
 # Run the app by default when the container starts
-CMD /app/app
+CMD ["/app/app"]


### PR DESCRIPTION
This will make our process run as pid1 in the container. This removes
the need for having a shell in the final container and is the preferred
way to use CMD according to the official docker documentation.